### PR TITLE
[python38-nox] Add test to python 3.7 and 3.8 explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
   - pip install setuptools
-  - pip install --user nox
+  - pip install nox
 
 script:
   - nox -e test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.7"
   - "3.8"
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - sudo apt install -y python3-pip
 
 install:
+  - pip3 install setuptools
   - pip3 install --user nox
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
+  - "2.7"
   - "3.7"
   - "3.8"
+  - "pypy"
 dist: xenial
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.7"
   - "3.7"
   - "3.8"
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
-language: generic
+language: python
+python:
+  - "3.7"
 dist: bionic
 
 before_install:
   - sudo pyenv install python2.7
-  - sudo pyenv install python3.7
   - sudo pyenv install python3.8
   - sudo pyenv install pypy
   - python2.7 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: generic
 dist: bionic
 
 before_install:
-  - curl -sSf --retry 5 -o python-3.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/python-3.8.tar.bz2
-  - sudo tar xjf python-3.8.tar.bz2 --directory /
-  - curl -sSf --retry 5 -o python-3.7.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/python-3.7.tar.bz2
-  - sudo tar xjf python-3.7.tar.bz2 --directory /
-  - curl -sSf --retry 5 -o pypy2.7-7.2.0.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/pypy2.7-7.2.0.tar.bz2
-  - sudo tar xjf pypy2.7-7.2.0.tar.bz2 --directory /
+  - sudo pyenv install python2.7
+  - sudo pyenv install python3.7
+  - sudo pyenv install python3.8
+  - sudo pyenv install pypy
   - python2.7 --version
   - python3.7 --version
   - python3.8 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-python: 3.7
+python:
+  - "3.7"
+  - "3.8"
 dist: xenial
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
 dist: bionic
 
 before_install:
-  - pyenv install 2.7
-  - pyenv install 3.8
-  - pyenv install pypy
+  - pyenv install -s 2.7
+  - pyenv install -s 3.8
+  - pyenv install -s pypy
   - python2.7 --version
   - python3.7 --version
   - python3.8 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 dist: bionic
 
 install:
-  - pip3 install nox
+  - pip3 install --user nox
 
 script:
   - nox -e test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
   - pip install nox
 
 script:
-  - nox -e test -p $TRAVIS_PYTHON_VERSION
-  - nox -e lint -p $TRAVIS_PYTHON_VERSION
+  - nox -e test-$TRAVIS_PYTHON_VERSION
+  - nox -e lint-$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: generic
 dist: bionic
 
 install:
+  - sudo apt install python3-pip
   - pip3 install --user nox
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,10 @@ before_install:
   - python3.7 --version
   - python3.8 --version
   - pypy --version
-  - sudo apt-get update
-  - sudo apt install -y python3-pip
 
 install:
-  - pip3 install setuptools
-  - pip3 install --user nox
+  - pip install setuptools
+  - pip install --user nox
 
 script:
   - nox -e test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 dist: xenial
 
 before_install:
-  - apt-get install python3.8
+  - sudo apt-get install python3.8
 
 install:
   - pip install nox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 dist: bionic
 
 install:
-  - pip install nox
+  - pip3 install nox
 
 script:
   - nox -e test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
   - "3.8"
 
-dist: xenial
+dist: bionic
 
 install:
   - pip install nox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 python:
   - "3.7"
-  - "3.8"
 dist: xenial
+
+before_install:
+  - apt-get install python3.8
 
 install:
   - pip install nox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dist: bionic
 before_install:
   - pyenv install -s 2.7
   - pyenv install -s 3.8
+  - pyenv local 2.7 3.7 3.8
   - python2.7 --version
   - python3.7 --version
   - python3.8 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: generic
 dist: bionic
 
 before_install:
+  - python2.7 --version
+  - python3.7 --version
+  - python3.8 --version
+  - pypy --version
   - sudo apt-get update
   - sudo apt install -y python3-pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 python:
   - "3.7"
+  - "3.8"
 dist: xenial
-
-before_install:
-  - sudo apt-get install python3.8
 
 install:
   - pip install nox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: generic
 dist: bionic
 
+before_install:
+  - sudo apt-get update
+  - sudo apt install -y python3-pip
+
 install:
-  - sudo apt install python3-pip
   - pip3 install --user nox
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
-python: 3.7
-dist: bionic
+python:
+  - "3.7"
+  - "3.8"
+dist: xenial
 
 install:
   - pip install nox
 
 script:
-  - nox -e test
-  - nox -e lint
+  - nox -e test -p $TRAVIS_PYTHON_VERSION
+  - nox -e lint -p $TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: generic
 dist: bionic
 
 before_install:
+  - curl -sSf --retry 5 -o python-3.8.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/python-3.8.tar.bz2
+  - sudo tar xjf python-3.8.tar.bz2 --directory /
+  - curl -sSf --retry 5 -o python-3.7.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/python-3.7.tar.bz2
+  - sudo tar xjf python-3.7.tar.bz2 --directory /
+  - curl -sSf --retry 5 -o pypy2.7-7.2.0.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/pypy2.7-7.2.0.tar.bz2
+  - sudo tar xjf pypy2.7-7.2.0.tar.bz2 --directory /
   - python2.7 --version
   - python3.7 --version
   - python3.8 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ dist: bionic
 before_install:
   - pyenv install -s 2.7
   - pyenv install -s 3.8
-  - pyenv install -s pypy
   - python2.7 --version
   - python3.7 --version
   - python3.8 --version
-  - pypy --version
 
 install:
   - pip install setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
 dist: bionic
 
 before_install:
-  - sudo pyenv install python2.7
-  - sudo pyenv install python3.8
-  - sudo pyenv install pypy
+  - pyenv install python2.7
+  - pyenv install python3.8
+  - pyenv install pypy
   - python2.7 --version
   - python3.7 --version
   - python3.8 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
-
-python:
-  - "3.7"
-  - "3.8"
-
+python: 3.7
 dist: bionic
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
-language: python
-python:
-  - "2.7"
-  - "3.7"
-  - "3.8"
-  - "pypy"
-dist: xenial
+language: generic
+dist: bionic
 
 install:
-  - pip3 install nox
+  - pip install nox
 
 script:
-  - nox -e test-$TRAVIS_PYTHON_VERSION
-  - nox -e lint-$TRAVIS_PYTHON_VERSION
+  - nox -e test
+  - nox -e lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 dist: xenial
 
 install:
-  - pip install nox
+  - pip3 install nox
 
 script:
   - nox -e test-$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
+
 python:
   - "3.7"
   - "3.8"
+
 dist: xenial
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 dist: bionic
 
 before_install:
-  - pyenv install python2.7
-  - pyenv install python3.8
+  - pyenv install 2.7
+  - pyenv install 3.8
   - pyenv install pypy
   - python2.7 --version
   - python3.7 --version

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The decorator in this package will always work because it actually modifies your
 
 ## Why would I not use this?
 
-This decorator inherently requires custom code for each Python implementation. Currently this is only tested against CPython 2.7, CPython 3.7 and PyPy 2.7.
+This decorator inherently requires custom code for each Python implementation. Currently this is only tested against CPython 2.7, CPython 3.7, CPython 3.8 and PyPy 2.7.
 
 ## License
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,16 +1,16 @@
 import functools
 import nox
 
-session = functools.partial(nox.session)
+session = functools.partial(nox.session, reuse_venv=True)
 
 
-@session(python=["2.7", "3.7", "3.8", "pypy"])
+@session(python=["2", "3.7", "3.8", "pypy"])
 def test(session):
     session.install("pytest")
     session.run("pytest", "tests/")
 
 
-@session(python=["2.7", "3.7", "3.8"])
+@session(python=["3.7", "3.8"])
 def lint(session):
     session.install("black")
     session.install("flake8")
@@ -21,13 +21,13 @@ def lint(session):
     session.run("mypy", "tests", "sensitive_variables")
 
 
-@session(python=["2.7", "3.7", "3.8"])
+@session(python=["3.7", "3.8"])
 def format(session):
     session.install("black")
     session.run("black", ".")
 
 
-@session(python=["2.7", "3.7", "3.8"])
+@session(python=["3.7", "3.8"])
 def release(session):
     session.install("twine")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ def test(session):
     session.run("pytest", "tests/")
 
 
-@session(python=["2.7", "3.7", "3.8", "pypy"])
+@session(python=["3.7"])
 def lint(session):
     session.install("black")
     session.install("flake8")

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,13 +4,13 @@ import nox
 session = functools.partial(nox.session, reuse_venv=True)
 
 
-@session(python=["2", "3.7", "3.8", "pypy"])
+@session(python=["2.7", "3.7", "3.8", "pypy"])
 def test(session):
     session.install("pytest")
     session.run("pytest", "tests/")
 
 
-@session(python=["3.7", "3.8"])
+@session(python=["2.7", "3.7", "3.8", "pypy"])
 def lint(session):
     session.install("black")
     session.install("flake8")
@@ -21,13 +21,13 @@ def lint(session):
     session.run("mypy", "tests", "sensitive_variables")
 
 
-@session(python=["3.7", "3.8"])
+@session(python=["3.7"])
 def format(session):
     session.install("black")
     session.run("black", ".")
 
 
-@session(python=["3.7", "3.8"])
+@session(python=["3.7"])
 def release(session):
     session.install("twine")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,13 +4,13 @@ import nox
 session = functools.partial(nox.session)
 
 
-@session(python=["2", "3.7", "3.8", "pypy"])
+@session(python=["2.7", "3.7", "3.8", "pypy"])
 def test(session):
     session.install("pytest")
     session.run("pytest", "tests/")
 
 
-@session(python=["3.7", "3.8"])
+@session(python=["2.7", "3.7", "3.8"])
 def lint(session):
     session.install("black")
     session.install("flake8")
@@ -21,13 +21,13 @@ def lint(session):
     session.run("mypy", "tests", "sensitive_variables")
 
 
-@session(python=["3.7", "3.8"])
+@session(python=["2.7", "3.7", "3.8"])
 def format(session):
     session.install("black")
     session.run("black", ".")
 
 
-@session(python=["3.7", "3.8"])
+@session(python=["2.7", "3.7", "3.8"])
 def release(session):
     session.install("twine")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import functools
 import nox
 
-session = functools.partial(nox.session, reuse_venv=True)
+session = functools.partial(nox.session)
 
 
 @session(python=["2", "3.7", "3.8", "pypy"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ def test(session):
     session.run("pytest", "tests/")
 
 
-@session(python=["3"])
+@session(python=["3.7", "3.8"])
 def lint(session):
     session.install("black")
     session.install("flake8")
@@ -21,13 +21,13 @@ def lint(session):
     session.run("mypy", "tests", "sensitive_variables")
 
 
-@session(python=["3"])
+@session(python=["3.7", "3.8"])
 def format(session):
     session.install("black")
     session.run("black", ".")
 
 
-@session(python=["3"])
+@session(python=["3.7", "3.8"])
 def release(session):
     session.install("twine")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ import nox
 session = functools.partial(nox.session, reuse_venv=True)
 
 
-@session(python=["2", "3", "pypy"])
+@session(python=["2", "3.7", "3.8", "pypy"])
 def test(session):
     session.install("pytest")
     session.run("pytest", "tests/")

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,9 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*",
 )


### PR DESCRIPTION
This PR includes a few changes:
- Add python 3.8 support on nox
- Add python 3.8 on .travis.yml
- Remove python 3.6 and older from setup.py classifiers  
- Update README to include Python 3.8 support

What do you think?