### PR TITLE
Ensure cleaning when no arguments (clear not working)

### DIFF
--- a/sensitive_variables/__init__.py
+++ b/sensitive_variables/__init__.py
@@ -103,7 +103,9 @@ def _scrub_locals_from_traceback(traceback, names, depth=1, custom_scrub_fn=None
                     locals[name] = PLACEHOLDER
                     locals_modified = True
         else:
-            locals.clear()
+            if not names and not custom_scrub_fn:
+                for k, v in locals.items():
+                    locals[k] = PLACEHOLDER
             locals_modified = True
 
         if locals_modified:

--- a/sensitive_variables/__init__.py
+++ b/sensitive_variables/__init__.py
@@ -103,9 +103,8 @@ def _scrub_locals_from_traceback(traceback, names, depth=1, custom_scrub_fn=None
                     locals[name] = PLACEHOLDER
                     locals_modified = True
         else:
-            if not names and not custom_scrub_fn:
-                for k, v in locals.items():
-                    locals[k] = PLACEHOLDER
+            for k, v in locals.items():
+                locals[k] = PLACEHOLDER
             locals_modified = True
 
         if locals_modified:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -67,7 +67,7 @@ def test_basic_no_arguments(no_cyclic_references):
         @sensitive_variables()
         def login_user(username, password):
             is_inside_func = True  # noqa
-            to_clean = {"dict": "a"}
+            to_clean = {"dict": "a"}  # noqa
             print("logging in " + username + password)
 
         try:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -59,6 +59,37 @@ def test_basic(no_cyclic_references):
     no_cyclic_references(f)
 
 
+def test_basic_no_arguments(no_cyclic_references):
+    def f():
+        is_test_func = True  # noqa
+
+        # This should clean everything!
+        @sensitive_variables()
+        def login_user(username, password):
+            is_inside_func = True  # noqa
+            to_clean = {"dict": "a"}
+            print("logging in " + username + password)
+
+        try:
+            login_user(None, "secret123")
+        except TypeError:
+            test_locals, wrapper_locals, locals = get_all_variables()
+        else:
+            assert False
+
+        # Assert that we got the right frames
+        assert test_locals["is_test_func"]
+        assert locals["is_inside_func"]
+        assert wrapper_locals["f"]
+
+        # Assert real functionality
+        assert locals["password"] == PLACEHOLDER
+        assert "secret123" not in list(locals.values())
+        assert locals["to_clean"] == PLACEHOLDER
+
+    no_cyclic_references(f)
+
+
 def test_basic_depth_2(no_cyclic_references):
     def f():
         is_test_func = True  # noqa


### PR DESCRIPTION
Hey! 

I'm not 100% sure about this but what should be the behavior when no variables name are set? Cleaning everything? It seems the "clear" doesn't work there so I changed the approach a bit.

Let me know if I misunderstood this.